### PR TITLE
fix plan width on mobile

### DIFF
--- a/pricing-table.sass
+++ b/pricing-table.sass
@@ -26,7 +26,9 @@ $pricing-price-background: white !default
     list-style-type: none
     transition: 0.25s
     margin: .5em
-
+    +mobile
+      width: auto
+    
     .plan-header
       border-top-left-radius: $pricing-plan-border-radius
       border-top-right-radius: $pricing-plan-border-radius


### PR DESCRIPTION
Because of the `width: 0` rule, the pricing plan has no width on mobile. I managed to fix it by resetting the width rule for mobile display.

Thanks for the awesome extension(s), they are very helpful.
